### PR TITLE
feat(fix): fix starknet.py version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         "fastecdsa",  # Not directly used, but part of install instructions for cairo-lang
         "sympy",  # Not directly used, but part of install instructions for cairo-lang
         "cairo-lang",
-        "starknet.py>=0.2.0a0,<0.3.0",
+        "starknet.py>=0.2.0a0,<0.2.3a0",
         "eth-ape>=0.2.1,<0.3.0",
         "ethpm-types>=0.1.1,<0.3.0",
         "importlib-metadata ; python_version<'3.8'",


### PR DESCRIPTION
### What I did

Fixes the ape importing error from the new version of starknet.py
fixes: #7

### How I did it

### How to verify it
Install ape-cairo from this pr and check that there is no error when we use the ape cli

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
