### PR TITLE
feat: dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,27 +1,27 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.2.0
     hooks:
     -   id: check-yaml
 
 -   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.9.3
+    rev: v5.10.1
     hooks:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
         name: black
 
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910-1
+    rev: v0.960
     hooks:
     -   id: mypy
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,54 @@ In a project directory where there are `.cairo` files in your `contracts/` direc
 ape compile
 ```
 
+### Configure Dependencies
+
+You can configure dependencies, such as from `GitHub`, using your `ape-config.yaml` file.
+
+There are two things you need to add:
+
+1. Add your dependency to Ape's root `dependencies:` key to trigger downloading and compiling it.
+2. Configure the `ape-cairo` plugin to load that dependency in your project.
+
+For more information on dependencies, [see this guide](https://docs.apeworx.io/ape/stable/userguides/config.html#dependencies).
+
+Your resulting `ape-config.yaml` will look something like:
+
+```yaml
+dependencies:
+  - name: OpenZeppelinCairo
+    github: OpenZeppelin/cairo-contracts
+    version: 0.1.0
+    contracts_folder: src
+
+cairo:
+  dependencies:
+    - OpenZeppelinCairo@0.1.0
+```
+
+**NOTE**: We are changing the `contracts/` folder to be `src` for this dependency.
+
+Now, in my `contracts/` folder, I can import from `openzeppelin`:
+
+```cairo
+from openzeppelin.token.erc20.library import (
+    ERC20_name,
+    ERC20_symbol,
+    ERC20_totalSupply,
+    ERC20_decimals,
+    ERC20_balanceOf,
+    ERC20_allowance,
+    ERC20_mint,
+    ERC20_burn,
+    ERC20_initializer,
+    ERC20_approve,
+    ERC20_increaseAllowance,
+    ERC20_decreaseAllowance,
+    ERC20_transfer,
+    ERC20_transferFrom
+)
+```
+
 ## Development
 
 This project is in development and should be considered a beta.

--- a/ape_cairo/__init__.py
+++ b/ape_cairo/__init__.py
@@ -1,6 +1,11 @@
 from ape import plugins
 
-from .compiler import CairoCompiler
+from .compiler import CairoCompiler, CairoConfig
+
+
+@plugins.register(plugins.Config)
+def config_class():
+    return CairoConfig
 
 
 @plugins.register(plugins.CompilerPlugin)

--- a/ape_cairo/compiler.py
+++ b/ape_cairo/compiler.py
@@ -1,13 +1,17 @@
 from pathlib import Path
 from typing import List, Optional, Set
 
-from ape.api import CompilerAPI
-from ape.exceptions import CompilerError
+from ape.api import CompilerAPI, PluginConfig
+from ape.exceptions import CompilerError, ConfigError
 from ape.utils import get_relative_path
-from ethpm_types import ContractType
+from ethpm_types import ContractType, PackageManifest
 from pkg_resources import get_distribution  # type: ignore
-from starknet_py.compile.compiler import starknet_compile  # type: ignore
+from starknet_py.compile.compiler import StarknetCompilationSource, starknet_compile  # type: ignore
 from starkware.starknet.services.api.contract_definition import ContractDefinition  # type: ignore
+
+
+class CairoConfig(PluginConfig):
+    dependencies: List[str] = []
 
 
 class CairoCompiler(CompilerAPI):
@@ -15,22 +19,94 @@ class CairoCompiler(CompilerAPI):
     def name(self) -> str:
         return "cairo"
 
+    @property
+    def config(self) -> CairoConfig:
+        return self.config_manager.get_config("cairo")  # type: ignore
+
+    def load_dependencies(self, base_path: Optional[Path] = None):
+        base_path = base_path or self.config_manager.contracts_folder
+        packages_folder = self.config_manager.packages_folder
+
+        for dependency_item in self.config.dependencies:
+            if "@" not in dependency_item:
+                dependency_name = dependency_item
+                version = None
+            else:
+                dependency_name, version = dependency_item.split("@")
+
+            dependency_package_folder = packages_folder / dependency_name
+            if version is None:
+                version_options = [d for d in dependency_package_folder.iterdir() if d.is_dir()]
+                if not version_options:
+                    raise ConfigError(f"No versions found for dependency '{dependency_name}'.")
+
+                elif len(version_options) != 1:
+                    raise ConfigError(
+                        f"Ambiguous dependency version for '{dependency_name}'. "
+                        f"Use 'name@version' syntax to clarify."
+                    )
+
+                version = version_options[0].name
+
+            if version[0].isnumeric():
+                version = f"v{version}"
+
+            source_manifest_path = (
+                packages_folder / dependency_name / version / f"{dependency_name}.json"
+            )
+            source_manifest = PackageManifest.parse_raw(source_manifest_path.read_text())
+            destination_base_path = base_path / ".cache" / dependency_name / version
+
+            if dependency_name not in [d.name for d in self.config_manager.dependencies]:
+                raise ConfigError(f"Dependency '{dependency_item}' not configured.")
+
+            sources = source_manifest.sources or {}
+            for source_id, source in sources.items():
+                suffix = Path(f"{source_id.replace('.cairo', '').replace('.', '/')}.cairo")
+                destination_path = destination_base_path / suffix
+
+                if destination_path.is_file():
+                    continue
+
+                if source.content:
+                    destination_path.parent.mkdir(parents=True, exist_ok=True)
+                    destination_path.touch()
+                    destination_path.write_text(source.content)
+
     def get_versions(self, all_paths: List[Path]) -> Set[str]:
         # NOTE: Currently, we are not doing anything with versions.
         return {get_distribution("cairo-lang").version}
 
     def compile(
-        self, contract_filepaths: List[Path], base_path: Optional[Path]
+        self, contract_filepaths: List[Path], base_path: Optional[Path] = None
     ) -> List[ContractType]:
+        base_path = base_path or self.project_manager.contracts_folder
+
+        # NOTE: still load dependencies even if no contacts in project.
+        self.load_dependencies()
+
         if not contract_filepaths:
             return []
 
         contract_types = []
-        for contract_path in contract_filepaths:
-            search_paths = [base_path] if base_path else []
+        base_cache_path = base_path / ".cache"
 
+        cached_paths_to_add = []
+        dependency_folders = (
+            [base_cache_path / p for p in base_cache_path.iterdir() if p.is_dir()]
+            if base_cache_path.is_dir()
+            else []
+        )
+        for dependency_folder in dependency_folders:
+            cached_paths_to_add.extend(
+                [dependency_folder / p for p in dependency_folder.iterdir() if p.is_dir()]
+            )
+
+        search_paths = [base_path, *cached_paths_to_add]
+        for contract_path in contract_filepaths:
             try:
-                result_str = starknet_compile(contract_path.read_text(), search_paths=search_paths)
+                source = StarknetCompilationSource(str(contract_path))
+                result_str = starknet_compile([source], search_paths=search_paths)
             except ValueError as err:
                 raise CompilerError(f"Failed to compile '{contract_path.name}': {err}") from err
 

--- a/ape_cairo/compiler.py
+++ b/ape_cairo/compiler.py
@@ -24,6 +24,7 @@ class CairoCompiler(CompilerAPI):
         return self.config_manager.get_config("cairo")  # type: ignore
 
     def load_dependencies(self, base_path: Optional[Path] = None):
+        _ = self.project_manager.dependencies
         contracts_path = base_path or self.config_manager.contracts_folder
         packages_folder = self.config_manager.packages_folder
 

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ extras_require = {
     ],
     "lint": [
         "black>=22.3.0,<23.0",  # auto-formatter and linter
-        "mypy>=0.950,<1.0",  # Static type analyzer
-        "flake8>=3.9.2,<4.0",  # Style linter
+        "mypy>=0.960,<1.0",  # Static type analyzer
+        "flake8>=4.0.1,<5.0",  # Style linter
         "isort>=5.10.1,<6.0",  # Import sorting linter
     ],
     "release": [  # `release` GitHub Action job uses this
@@ -58,7 +58,7 @@ setup(
         "sympy",  # Not directly used, but part of install instructions for cairo-lang
         "cairo-lang",
         "starknet.py>=0.2.3a0,<0.2.4",
-        "eth-ape>=0.2.4,<0.3.0",
+        "eth-ape>=0.2.7,<0.3.0",
         "ethpm-types",
         "importlib-metadata ; python_version<'3.8'",
     ],  # NOTE: Add 3rd party libraries here

--- a/tests/ape-config.yaml
+++ b/tests/ape-config.yaml
@@ -1,1 +1,10 @@
 contracts_folder: contracts
+
+dependencies:
+  - name: TestDependency
+    local: ./dependency
+    contracts_folder: src
+
+cairo:
+  dependencies:
+    - TestDependency

--- a/tests/contracts/UseDependency.cairo
+++ b/tests/contracts/UseDependency.cairo
@@ -1,0 +1,5 @@
+# NOTE: This contract is for test purposes only.
+# Its intent is to provide a variety of ABI types to test against.
+%lang starknet
+
+from dependency.Dependency import DependencyStruct

--- a/tests/dependency/src/dependency/Dependency.cairo
+++ b/tests/dependency/src/dependency/Dependency.cairo
@@ -1,0 +1,9 @@
+# NOTE: This contract is for test purposes only.
+# Its intent is to provide a variety of ABI types to test against.
+%lang starknet
+
+# Make sure we can compile structs.
+struct DependencyStruct:
+    member foo : felt
+    member bar : felt
+end

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -5,7 +5,9 @@ from tests.conftest import SOURCE_CODE_DIRECTORY, SOURCE_FILES
 
 def test_compile_all_files(compiler, project):
     source_files = [SOURCE_CODE_DIRECTORY / s for s in SOURCE_FILES]
-    compiler.compile(source_files, base_path=SOURCE_CODE_DIRECTORY)
+    result = compiler.compile(source_files, base_path=SOURCE_CODE_DIRECTORY)
+    assert len(result) == len(source_files)
+
     for src_file in SOURCE_FILES:
         expected = get_expected_contract_type_name(src_file)
         assert project.get_contract(expected)
@@ -20,7 +22,8 @@ def test_compile_all_files(compiler, project):
 
 
 def test_compile_individual_files(compiler, contract, project):
-    compiler.compile([contract], base_path=SOURCE_CODE_DIRECTORY)
+    result = compiler.compile([contract], base_path=SOURCE_CODE_DIRECTORY)
+    assert len(result) == 1
     expected = get_expected_contract_type_name(contract)
     assert project.get_contract(expected)
     assert getattr(project, expected)

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,20 +1,20 @@
 from pathlib import Path
 
-from tests.conftest import SOURCE_CODE_DIRECTORY, SOURCE_FILES
+from tests.conftest import SOURCE_FILES
 
 
 def test_compile_all_files(compiler, project):
-    source_files = [SOURCE_CODE_DIRECTORY / s for s in SOURCE_FILES]
-    result = compiler.compile(source_files, base_path=SOURCE_CODE_DIRECTORY)
+    source_files = [project.contracts_folder / s for s in SOURCE_FILES]
+    result = compiler.compile(source_files)
     assert len(result) == len(source_files)
 
     for src_file in SOURCE_FILES:
-        expected = get_expected_contract_type_name(src_file)
+        expected = get_expected_contract_type_name(src_file, project.contracts_folder)
         assert project.get_contract(expected)
         assert getattr(project, expected)
 
     # Make sure can call compile twice
-    compiler.compile(source_files, base_path=SOURCE_CODE_DIRECTORY)
+    compiler.compile(source_files)
 
     # Make sure can actually use dot-access
     assert project.namespace0.library
@@ -22,19 +22,19 @@ def test_compile_all_files(compiler, project):
 
 
 def test_compile_individual_files(compiler, contract, project):
-    result = compiler.compile([contract], base_path=SOURCE_CODE_DIRECTORY)
+    result = compiler.compile([contract])
     assert len(result) == 1
-    expected = get_expected_contract_type_name(contract)
+    expected = get_expected_contract_type_name(contract, project.contracts_folder)
     assert project.get_contract(expected)
     assert getattr(project, expected)
 
     # Make sure can call compile twice
-    compiler.compile([contract], base_path=SOURCE_CODE_DIRECTORY)
+    compiler.compile([contract])
 
 
-def test_event_abi_migration(compiler):
-    contract_with_event = SOURCE_CODE_DIRECTORY / "oz_proxy_lib.cairo"
-    contract_type = compiler.compile([contract_with_event], base_path=SOURCE_CODE_DIRECTORY)[0]
+def test_event_abi_migration(compiler, project):
+    contract_with_event = project.contracts_folder / "oz_proxy_lib.cairo"
+    contract_type = compiler.compile([contract_with_event])[0]
     event_abi = [abi for abi in contract_type.abi if abi.type == "event"][0]
     assert len(event_abi.inputs) == 1
     assert event_abi.inputs[0].name == "implementation"
@@ -42,13 +42,13 @@ def test_event_abi_migration(compiler):
     assert not event_abi.inputs[0].indexed
 
 
-def get_expected_contract_type_name(contract_path: Path) -> str:
+def get_expected_contract_type_name(contract_path: Path, base_path: Path) -> str:
     """
     Converts paths like Path("path/to/base_dir/namespace/library.cairo") -> "namespace.library".
     """
     return (
         str(contract_path)
-        .replace(str(SOURCE_CODE_DIRECTORY), "")
+        .replace(str(base_path), "")
         .replace(".cairo", "")
         .strip("/")
         .replace("/", ".")


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #4 

### How I did it

Goods news is that dependencies in cairo is not so hard.

* Allow user to configure dependencies (See README for example)
* Automatically load those source files into the `.cache` / `depname` / `version` (exactly as `ape-solidity` does)
* Add those result cached source files to the list of paths to look for in the cairo compiler command.

Boom! Now you can use dependencies.

### How to verify it

I added an example to my demo project: https://github.com/unparalleled-js/ape-demo-starknet

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
