### PR TITLE
chore: bump ape to 0.5

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -16,7 +16,7 @@ $ ape plugins list
 ```
 
 * Python Version: x.x.x
-* OS: osx/linux/win
+* OS: macOS/linux/win
 
 ### What went wrong?
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,4 +27,4 @@ repos:
 
 
 default_language_version:
-    python: python3.9
+    python: python3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ape Cairo
+# Quick Start
 
 Ape compiler plugin around [the Cairo language](https://github.com/starkware-libs/cairo-lang).
 
@@ -87,7 +87,3 @@ from openzeppelin.token.erc20.library import (
 This project is in development and should be considered a beta.
 Things might not be in their final state and breaking changes may occur.
 Comments, questions, criticisms and pull requests are welcomed.
-
-## License
-
-This project is licensed under the [Apache 2.0](LICENSE).

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "eth-ape>=0.5.0,<0.6.0",
         "ethpm-types",
     ],
-    python_requires=">=3.8,<4",
+    python_requires=">=3.8,<3.11",
     extras_require=extras_require,
     py_modules=["ape_cairo"],
     license="Apache-2.0",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     install_requires=[
         "cairo-lang>=0.10.0,<0.11",
         "starknet.py>=0.5.1a0,<0.6",
-        "eth-ape>=0.4.5,<0.5.0",
+        "eth-ape>=0.5.0,<0.6.0",
         "ethpm-types",
     ],
     python_requires=">=3.8,<4",


### PR DESCRIPTION
This repo already had removed some Python 3.7 stuff so not much to update here 🙂 