### PR TITLE
chore: bump starknet.py supported version range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "cairo-lang>=0.10.0,<0.11",
-        "starknet.py>=0.5.1a0,<0.6",
+        "starknet.py>=0.6.0a0,<0.7",
         "eth-ape>=0.5.1,<0.6",
         "ethpm-types",
     ],


### PR DESCRIPTION
### What I did

Needed for https://github.com/ApeWorX/ape-starknet/pull/92

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
