### PR TITLE
fix: support `starknet.py upgrade`

### DIFF
--- a/ape_cairo/compiler.py
+++ b/ape_cairo/compiler.py
@@ -6,7 +6,7 @@ from ape.exceptions import CompilerError, ConfigError
 from ape.utils import get_relative_path
 from ethpm_types import ContractType, PackageManifest
 from pkg_resources import get_distribution  # type: ignore
-from starknet_py.compile.compiler import StarknetCompilationSource, starknet_compile  # type: ignore
+from starknet_py.compile.compiler import CairoFilename, starknet_compile  # type: ignore
 from starkware.starknet.services.api.contract_class import ContractClass  # type: ignore
 
 
@@ -116,7 +116,7 @@ class CairoCompiler(CompilerAPI):
         search_paths = [base_path, *cached_paths_to_add]
         for contract_path in contract_filepaths:
             try:
-                source = StarknetCompilationSource(str(contract_path))
+                source = CairoFilename(str(contract_path))
                 is_account = _has_account_methods(contract_path)
                 result_str = starknet_compile(
                     [source], search_paths=search_paths, is_account_contract=is_account

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "cairo-lang>=0.10.0,<0.11",
-        "starknet.py>=0.6.0a0,<0.7",
+        "starknet.py>=0.6.2a0,<0.7",
         "eth-ape>=0.5.1,<0.6",
         "ethpm-types",
     ],


### PR DESCRIPTION
### What I did

Resolved `TypeError` from latest starknet.py release

### How I did it

Adjust import.
Bump version.

### How to verify it

Things work again.
Downstream `ape-starknet` PR works.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
